### PR TITLE
Fixed issue with utf8 characters and state reset

### DIFF
--- a/src/Lumina.pas
+++ b/src/Lumina.pas
@@ -5434,6 +5434,8 @@ var
 begin
   Result := False;
 
+  FTokenResponse := Default(TTokenResponse);
+
   if not Assigned(FModel) then
   begin
     SetError('No model loaded', []);
@@ -5552,6 +5554,18 @@ begin
     end;
 
     LBatch := llama_batch_get_one(@LNewTokenId, 1);
+  end;
+
+  if FTokenResponse.Finalize then
+  begin
+    case FTokenResponse.AddToken('') of
+      tpaAppend: OnNextToken(FTokenResponse.LastWord(False));
+      tpaNewline:
+      begin
+        OnNextToken(#10);
+        OnNextToken(FTokenResponse.LastWord(True));
+      end;
+    end;
   end;
 
   FPerf := CalcPerformance(LCtx);


### PR DESCRIPTION
Making sure to reset state before each simpleinference and fixed issue with german characters causing the output buffer to not be sent, leaving chars in the buffer which got output on the next inference response.